### PR TITLE
Update command to install brew on macOS

### DIFF
--- a/ddrescue.rst
+++ b/ddrescue.rst
@@ -29,7 +29,7 @@ To install ddrescue:
 .. code-block:: none
 
 
-   ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
    brew install ddrescue
 
 Done! You can now use :command:`ddrescue`.


### PR DESCRIPTION
As per `brew` instructions found at [brew.sh](https://brew.sh)

```
Warning: The Ruby Homebrew installer is now deprecated and has been rewritten in Bash. Please migrate to the following command:
  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
```