### PR TITLE
Compile from source on macOS

### DIFF
--- a/compilation_env.rst
+++ b/compilation_env.rst
@@ -21,7 +21,8 @@ Linux
 
 macOS
 -----
-Install Xcode
+
+ * Using HomeBrew: ``brew install gcc``
 
 Windows
 -------


### PR DESCRIPTION
I tried to compile from source `testdisk` on macOS Catalina with success, at least until now.

I first tried to compile without Xcode and without any `c` compiler to be able to compare changes on `./compile` after adding one.

Then installed `gcc` using brew and the `./compile` step went enough fine to continue to next step, then, I ran a `make` and `make install` with also good enough results.

I know there are some missing _Warnings_ on the configure step related mostly to `qt5`, `ntfs` & `ext` support but it may be a start to compile from source `testdisk` on macOS.

Finally, tried to make a recovery from a USB pendrive formatted with `exFat` and all went fine.

I hope to address those warnings later if manage to get the time. Do you mind in taking this progress?

---

Logs on configure & make:

  - https://gist.github.com/cetinajero/e9ac94ae1254166986726c7b77b91018

---

`testdrive` version:

```
TestDisk 7.2-WIP, Data Recovery Utility, September 2020
Christophe GRENIER <grenier@cgsecurity.org>
https://www.cgsecurity.org

Version: 7.2-WIP
Compiler: GCC 4.2
ext2fs lib: none, ntfs lib: none, reiserfs lib: none, ewf lib: none, curses lib: ncurses 5.7
OS: Darwin, kernel 19.6.0 (Darwin Kernel Version 19.6.0: Thu Jun 18 20:49:00 PDT 2020; root:xnu-6153.141.1~1/RELEASE_X86_64) x86_64
```

`photorec` version:

```
PhotoRec 7.2-WIP, Data Recovery Utility, September 2020
Christophe GRENIER <grenier@cgsecurity.org>
https://www.cgsecurity.org

Version: 7.2-WIP
Compiler: GCC 4.2
ext2fs lib: none, ntfs lib: none, ewf lib: none, libjpeg: 90, curses lib: ncurses 5.7, zlib: 1.2.11
OS: Darwin, kernel 19.6.0 (Darwin Kernel Version 19.6.0: Thu Jun 18 20:49:00 PDT 2020; root:xnu-6153.141.1~1/RELEASE_X86_64) x86_64
```
